### PR TITLE
Unpin balena-cli (from v11.31.17 to latest)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,10 @@ RUN apt-get update && apt-get install -y \
     curl \
     unzip && \
   cd /opt/ && \
-  #curl -s https://api.github.com/repos/balena-io/balena-cli/releases/latest | \
-  #  grep browser_download_url.*balena-cli-v.*-linux-x64-standalone.zip | \
-  #  cut -d : -f 2,3 | \
-  #  xargs -n 1 curl -O -sSL && \
-  curl -O -sSL https://github.com/balena-io/balena-cli/releases/download/v11.31.17/balena-cli-v11.31.17-linux-x64-standalone.zip && \
+  curl -s https://api.github.com/repos/balena-io/balena-cli/releases/latest | \
+    grep browser_download_url.*balena-cli-v.*-linux-x64-standalone.zip | \
+    cut -d : -f 2,3 | \
+    xargs -n 1 curl -O -sSL && \
   unzip balena-cli-*-linux-x64-standalone.zip && \
   ln -s /opt/balena-cli/balena /usr/bin/ && \
   apt-get purge -y \


### PR DESCRIPTION
I am creating this PR on behalf of a balena user who contacted balena's support team to report ESOCKETTIMEDOUT errors when using this GitHub action. It turns out that those errors were fixed in balena-cli v12.11.1 ([changelog](https://github.com/balena-io/balena-cli/blob/master/CHANGELOG.md)), almost a year ago.

By the way, although not the cause of the errors, CLI v11 is now more than a year old and no longer supported. For reference, see Deprecation Policy in the Readme:
> https://github.com/balena-io/balena-cli/blob/master/README.md#deprecation-policy
> _The latest release of a major version of the balena CLI will remain compatible with the balenaCloud backend services for at least one year from the date when the following major version is released. For example, balena CLI v10.17.5, as the latest v10 release, would remain compatible with the balenaCloud backend for one year from the date when v11.0.0 is released._
